### PR TITLE
Updated all the node-fetch versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1385,7 +1385,7 @@
         "getenv": "0.7.0",
         "jimp": "0.12.1",
         "mime": "^2.4.4",
-        "node-fetch": "^2.6.0",
+        "node-fetch": "^2.6.1",
         "parse-png": "^2.1.0",
         "resolve-from": "^5.0.0",
         "semver": "7.3.2",
@@ -2312,7 +2312,7 @@
         "chalk": "^3.0.0",
         "lodash": "^4.17.15",
         "mime": "^2.4.1",
-        "node-fetch": "^2.6.0",
+        "node-fetch": "^2.6.1",
         "open": "^6.2.0",
         "shell-quote": "1.6.1"
       },
@@ -4932,7 +4932,7 @@
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "requires": {
-        "node-fetch": "^1.0.1",
+        "node-fetch": "^2.6.1",
         "whatwg-fetch": ">=0.10.0"
       }
     },
@@ -5486,7 +5486,7 @@
         "metro-symbolicate": "0.58.0",
         "mime-types": "2.1.11",
         "mkdirp": "^0.5.1",
-        "node-fetch": "^2.2.0",
+        "node-fetch": "^2.6.1",
         "nullthrows": "^1.1.1",
         "resolve": "^1.5.0",
         "rimraf": "^2.5.4",
@@ -6443,8 +6443,8 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
     "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
       "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
       "requires": {
         "encoding": "^0.1.11",


### PR DESCRIPTION
Dependabot cannot update node-fetch to a non-vulnerable version
The latest possible version of node-fetch that can be installed is 1.7.3.

The earliest fixed version is 2.6.1.

So I updated all of the node-fetch versions to 2.6.1